### PR TITLE
Add prompt cusps for the annihilation signal (v1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ Please send enquiries to Shin'ichiro Ando (s.ando@uva.nl). We have checked that 
 - Application to various primordial power spectra.
 - Including baryonic effects.
 
+## Prompt cusps (dark matter annihilation)
+
+The smallest dark matter halos form *prompt cusps* with steep central density profiles that dominate the annihilation signal. This is relevant **only when discussing annihilation**, so all prompt-cusp code lives in a separate module, `prompt_cusps.py`, which is imported lazily and is never loaded for standard (non-annihilation) runs. To switch it on, pass `prompt_cusps=True` when constructing a class:
+
+```python
+from sashimi_c import *
+
+sh = subhalo_observables(1.e12, prompt_cusps=True)   # M0/Msun; turns the prompt-cusp path on
+Bsh, Bcusp_dressed, Bcusp_naked, luminosity_ratio, Ncusp_dressed, Ncusp_naked \
+    = sh.annihilation_boost_factor_prompt_cusps(n=0)
+```
+
+With `prompt_cusps=True`, sigma(M) is computed from the CAMB linear matter power spectrum (with a free-streaming cutoff set by `k_fs_Mpc` / `filter` / `alpha`) instead of the Ludlow fit. The higher-order (`n>0`) boost tables are pre-computed with `boost_iteration_prompt_cusps.py`. See Ando et al. (arXiv:2601.19863).
+
+## Versions
+
+| Version | Description |
+|---------|-------------|
+| v1.0 | First public release. |
+| v1.1 | Improved computational efficiency (perturbative evaluation of tidal stripping). |
+| v1.2 | Prompt cusps for the annihilation signal (opt-in via `prompt_cusps=True`, isolated in `prompt_cusps.py`), plus general fixes. |
+
+**Note (v1.2):** the default of `ct_th` (tidal-disruption threshold) changed from `0.77` to `0.0` (no disruption). This affects results for *all* users, not only prompt-cusp runs; pass `ct_th=0.77` to recover the previous behavior. v1.2 also includes a fix to `dDdz` and other minor corrections.
+
 ## References
 
 When you use the outcome of this package for your scientific output, please cite the following publications.
@@ -49,6 +73,7 @@ The SASHIMI codes depend on results from various earlier papers. Listed below ar
 - (Evolution of host halo mass) https://arxiv.org/abs/1409.5228
 - (Extended Press-Schechter model) https://arxiv.org/abs/1104.1757
 - (Power spectrum and rms mass density) https://arxiv.org/abs/1601.02624
+- (Prompt cusps and dark matter annihilation) https://arxiv.org/abs/2601.19863
 
 ## Examples
 
@@ -94,7 +119,8 @@ M0: Mass of the host halo defined as M_{200} (200 times critial density) at *z =
                            used in Na_calc. (default: 200)
 (Optional) Na_model:       Model number of EPS defined in Yang et al. (2011). (default: 3)
 (Optional) ct_th:          Threshold value for c_t(=r_t/r_s) parameter, below which a subhalo is assumed to
-                           be completely desrupted. Suggested values: 0.77 (default) or 0 (no desruption).
+                           be completely desrupted. Suggested values: 0.77 (disruption) or 0.0
+                           (no desruption; default since v1.2).
 (Optional) profile_change: Whether we implement the evolution of subhalo density profile through tidal
                            mass loss. (default: True)
 (Optional) M0_at_redshift: If True, M0 is regarded as the mass at a given redshift, instead of z=0.

--- a/boost_iteration_prompt_cusps.py
+++ b/boost_iteration_prompt_cusps.py
@@ -1,0 +1,56 @@
+from sashimi_c import *
+import os
+import tqdm
+
+f_surv          = 1.
+f_surv_stripped = 1.
+
+n_values = [0,1,2,3,4,5]
+
+if not os.path.exists('data/prompt_cusps/boost'):
+    os.makedirs('data/prompt_cusps/boost',exist_ok=True)
+
+sh = subhalo_properties()
+
+list_za  = np.arange(0.,7.,0.1)
+ma_max   = sh.Mzi(1.e16,list_za)
+list_ma  = np.logspace(-5,np.log10(ma_max/sh.Msun),22).T*sh.Msun
+
+np.savetxt('data/prompt_cusps/boost/za.txt',list_za)
+np.savetxt('data/prompt_cusps/boost/ma.txt',list_ma)
+
+list_fsh            = np.empty_like(list_ma)
+list_Bsh            = np.empty_like(list_ma)
+list_Bcusp_dressed  = np.empty_like(list_ma)
+list_Bcusp_naked    = np.empty_like(list_ma)
+list_Ncusp_dressed  = np.empty_like(list_ma)
+list_Ncusp_naked    = np.empty_like(list_ma)
+
+for n in n_values:
+    print(f"Running for n = {n}")
+    for i,za in tqdm.tqdm(enumerate(list_za),total=len(list_za)):
+        #print(za)
+        #print(np.log10(list_ma[i]/sh.Msun))
+        for j,ma in enumerate(list_ma[i]):
+            sh    = subhalo_observables(ma/sh.Msun,za,M0_at_redshift=True,prompt_cusps=True,logmamin=-9,ct_th=0.0,N_ma=600)
+            fsh   = sh.mass_fraction()
+            Bsh, Bcusp_dressed, Bcusp_naked, luminosity_ratio, Ncusp_dressed, Ncusp_naked \
+                = sh.annihilation_boost_factor_prompt_cusps(n=n,f_surv=f_surv,f_surv_stripped=f_surv_stripped)
+
+            list_fsh[i,j]      = fsh
+            list_Bsh[i,j]      = Bsh
+            list_Bcusp_dressed[i,j] = Bcusp_dressed
+            list_Bcusp_naked[i,j]   = Bcusp_naked
+            list_Ncusp_dressed[i,j] = Ncusp_dressed
+            list_Ncusp_naked[i,j]   = Ncusp_naked
+            #print(za,np.log10(ma/sh.Msun),fsh,Bsh,Bcusp_dressed,Bcusp_naked,
+            #      np.log10(Ncusp_dressed),np.log10(Ncusp_naked))
+
+    if not os.path.exists('data/prompt_cusps/boost/fsh.txt'):
+        np.savetxt('data/prompt_cusps/boost/fsh.txt',list_fsh)
+
+    np.savetxt('data/prompt_cusps/boost/Bsh_%s_%.1f_%.1f.txt'%(n,f_surv,f_surv_stripped),list_Bsh)
+    np.savetxt('data/prompt_cusps/boost/Bcusp_dressed_%s_%.1f_%.1f.txt'%(n,f_surv,f_surv_stripped),list_Bcusp_dressed)
+    np.savetxt('data/prompt_cusps/boost/Bcusp_naked_%s_%.1f_%.1f.txt'%(n,f_surv,f_surv_stripped),list_Bcusp_naked)
+    np.savetxt('data/prompt_cusps/boost/Ncusp_dressed_%s_%.1f_%.1f.txt'%(n,f_surv,f_surv_stripped),list_Ncusp_dressed)
+    np.savetxt('data/prompt_cusps/boost/Ncusp_naked_%s_%.1f_%.1f.txt'%(n,f_surv,f_surv_stripped),list_Ncusp_naked)

--- a/prompt_cusps.py
+++ b/prompt_cusps.py
@@ -1,0 +1,444 @@
+"""
+Prompt-cusp extension for SASHIMI-C.
+
+This module contains everything specific to *prompt cusps* (relevant only for the
+dark-matter annihilation signal). It is imported lazily by ``sashimi_c`` and is
+NOT needed for standard SASHIMI-C usage:
+
+  * ``build_ps_interpolators`` is called by ``halo_model.__init__`` only when
+    ``prompt_cusps=True`` -- it replaces the Ludlow sigma(M) fit with sigma(M)
+    computed from the CAMB linear matter power spectrum (free-streaming cut off).
+  * ``prompt_cusps`` is the class used by
+    ``subhalo_observables.annihilation_boost_factor_prompt_cusps``.
+
+If ``prompt_cusps=False`` (the default) this module is never imported, so the
+non-annihilation pipeline is completely unaffected.
+
+Reference: Ando et al., arXiv:2601.19863.
+"""
+import numpy as np
+import os
+from scipy.integrate import simpson
+from scipy.interpolate import interp1d
+from scipy.optimize import root
+from scipy.special import erf
+
+from sashimi_c import cosmology
+
+
+def build_ps_interpolators(cosmo, k_fs, filter='Sharp-k', alpha=1.8,
+                           datafile='./data/Planck2018_CAMB_extrap.dat'):
+    """
+    Build ``sigma(M)`` and ``dsigma^2/dM`` interpolators for the prompt-cusp mass
+    function, from the CAMB linear matter power spectrum with a free-streaming
+    cutoff ``exp[-(k/k_fs)^2]``.
+
+    ``cosmo`` supplies ``OmegaM``, ``rhocrit0``, ``Mpc``, ``h``, ``Msun``.
+    Returns ``(sigma_interp, dsdm_interp)`` -- cubic-spline ``interp1d`` objects
+    over ``log10(M/Msun)``. Lifted out of ``sashimi_c.halo_model`` so the heavy
+    power-spectrum code is only loaded when ``prompt_cusps=True``.
+    """
+    k, Pk = np.loadtxt(datafile, unpack=True)
+    k  = k * (cosmo.Mpc / cosmo.h) ** -1
+    Pk = Pk * (cosmo.Mpc / cosmo.h) ** 3
+    Pk = Pk * np.exp(-(k / k_fs) ** 2)
+
+    def sigma_calc(M):
+        R = np.cbrt(3. * M / (4. * np.pi * cosmo.OmegaM * cosmo.rhocrit0))
+        if filter == 'TopHat':
+            R         = R[..., np.newaxis]
+            W         = 3 * (np.sin(k * R) / (k * R) - np.cos(k * R)) / (k * R) ** 2
+            integrand = k ** 3 * W ** 2 * Pk / (2. * np.pi ** 2)
+            sigma_sq  = simpson(integrand, x=np.log(k), axis=-1)
+        elif filter == 'Sharp-k':
+            kmin      = k[0]
+            kmax      = alpha / R
+            kk        = np.logspace(np.log10(kmin), np.log10(kmax), 1000)
+            fint      = interp1d(np.log(k), np.log(Pk))
+            Pkk       = np.exp(fint(np.log(kk)))
+            integrand = kk ** 3 * Pkk / (2. * np.pi ** 2)
+            sigma_sq  = simpson(integrand, x=np.log(kk), axis=0)
+        return np.sqrt(sigma_sq)
+
+    def dsdm_calc(M):
+        if filter == 'TopHat':
+            M         = M.reshape(-1, 1)
+            R         = np.cbrt(3. * M / (4. * np.pi * cosmo.OmegaM * cosmo.rhocrit0))
+            x         = k * R
+            dxdM      = x / (3. * M)
+            W         = 3 * (np.sin(x) / x - np.cos(x)) / x ** 2
+            dWdx      = (9. * np.cos(x)) / (x ** 3) - (9. * np.sin(x)) / (x ** 4) + (3. * np.sin(x)) / (x ** 2)
+            integrand = k ** 3 * Pk / (2. * np.pi ** 2) * 2. * W * dWdx * dxdM
+            return simpson(integrand, x=np.log(k), axis=-1)
+        elif filter == 'Sharp-k':
+            R     = np.cbrt(3. * M / (4. * np.pi * cosmo.OmegaM * cosmo.rhocrit0))
+            kmax  = alpha / R
+            fint  = interp1d(np.log(k), np.log(Pk))
+            Pkmax = np.exp(fint(np.log(kmax)))
+            return -kmax ** 3 * Pkmax / M / (6. * np.pi ** 2)
+
+    M_dummy = np.logspace(-12, 17, 2000) * cosmo.Msun
+    sigma_interp = interp1d(np.log10(M_dummy / cosmo.Msun), sigma_calc(M_dummy),
+                            kind='cubic', bounds_error=False, fill_value=None)
+    dsdm_interp  = interp1d(np.log10(M_dummy / cosmo.Msun), dsdm_calc(M_dummy),
+                            kind='cubic', bounds_error=False, fill_value=None)
+    return sigma_interp, dsdm_interp
+
+
+class prompt_cusps(cosmology):
+    
+    
+    def __init__(self, k_fs):
+        cosmology.__init__(self)
+        
+        self.GeV      = self.Msun/1.118e57
+        self.m_chi    = 100.*self.GeV
+        self.T_kd     = 0.03*self.GeV
+        self.a_kd     = 5.3e-12
+        self.k_fs     = k_fs
+        
+        
+    def powerspectrum(self, k, z=0.):
+        _z         = 31.
+        _a         = 1./(1.+_z)
+        a          = 1./(1.+z)
+        g          = 0.901
+        _k,_Delta2 = np.loadtxt('data/powerspectrum31.txt',unpack=True,delimiter=',')
+        _k        *= self.Mpc**-1
+        _Delta2   *= (a/_a)**(2.*g)
+        fint       = interp1d(np.log(_k),np.log(_Delta2),fill_value='extrapolate')
+        Delta2     = np.exp(fint(np.log(k)))
+        Delta2     = Delta2*np.exp(-(k/self.k_fs)**2)
+        
+        return Delta2
+
+    
+    def sigma_function(self, k=np.logspace(-1.,7.,num=1000)):
+        #Spectral parameters
+        k     = k/self.Mpc
+        sigma = np.empty(3)
+        for j in np.arange(3):
+            y        = self.powerspectrum(k=k)*k**(2*j)
+            sigma_sq = simpson(y,x=np.log(k))
+            sigma[j] = np.sqrt(sigma_sq)
+
+        #Comoving characteristic correlation length
+        R_s      = np.sqrt(3.)*sigma[1]/sigma[2]
+
+        #Deviation from pure power-law behaviour
+        gamma    = sigma[1]**2/(sigma[0]*sigma[2])
+
+        return np.array(sigma), R_s, gamma
+    
+
+    def cusps_Monte_Carlo(self, length=10000, nu_max=10.0, x_max=10.0, N_nu=1001, N_x=1000,
+                          rng_seed=None, verbose=False,
+    ):
+        """
+        Monte Carlo sampler for prompt-cusp peak parameters:
+        (nu, x) from BBKS peak density d^2n/(dnu dx),
+        (e, p) from the DW/BBKS (Doroshkevich-type) conditional ellipticity/prolateness distribution,
+        f_ec   solved from the collapse condition equation (as in your current code).
+
+        DW-consistent core (up to normalization):
+        f(e,p|nu) ∝ e (e^2 - p^2) exp[-(5/2) nu^2 (3 e^2 + p^2)]
+        With u=p/e:
+        f(e,u|nu) ∝ e^4 (1-u^2) exp[-alpha e^2],  alpha=(5/2) nu^2 (3+u^2)
+        => f(u|nu) ∝ (1-u^2) (3+u^2)^(-5/2)
+        => t=e^2 | (u,nu) ~ Gamma(shape=5/2, scale=1/alpha)
+
+        Returns
+        -------
+        x_random, nu_random, e_random, p_random, fec_random : 1D arrays (length,)
+        """
+
+        rng = np.random.default_rng(rng_seed)
+
+        # --- spectral parameters ---
+        sigma, R_s, gamma = self.sigma_function()
+
+        # --- BBKS f(x) ---
+        def f_x(x):
+            return ((x**3 - 3.0 * x) / 2.0) * (
+                erf(np.sqrt(5.0 / 2.0) * x) + erf(np.sqrt(5.0 / 8.0) * x)
+            ) + np.sqrt(2.0 / (5.0 * np.pi)) * (
+                (31.0 / 4.0 * x**2 + 8.0 / 5.0) * np.exp(-(5.0 / 8.0) * x**2)
+                + (x**2 / 2.0 - 8.0 / 5.0) * np.exp(-(5.0 / 2.0) * x**2)
+            )
+
+        # --- BBKS d^2n/(dnu dx) (matches your ddn() structure) ---
+        def d2n_dnudx(nu, x):
+            return (
+                np.exp(-0.5 * nu**2)
+                / ((2.0 * np.pi) ** 2 * R_s**3)
+                * f_x(x)
+                * np.exp(-0.5 * (x - gamma * nu) ** 2 / (1.0 - gamma**2))
+                / np.sqrt(2.0 * np.pi * (1.0 - gamma**2))
+            )
+
+        # --- sample (nu, x) on a grid via CDF inversion (stable; avoids p-sum issues) ---
+        nu_grid = np.linspace(1e-12, float(nu_max), int(N_nu))
+        x_grid = np.linspace(1e-12, float(x_max), int(N_x))
+
+        # weights on mesh: shape (N_nu, N_x)
+        w = d2n_dnudx(nu_grid.reshape(-1, 1), x_grid)
+        w = np.where(np.isfinite(w) & (w > 0.0), w, 0.0)
+
+        wsum = float(np.sum(w))
+        if not np.isfinite(wsum) or wsum <= 0.0:
+            raise ValueError("cusps_Monte_Carlo: peak weight integral is zero/invalid. Check sigma_function() output.")
+
+        w_flat = w.ravel()
+        cdf = np.cumsum(w_flat, dtype=np.float64)
+        cdf /= cdf[-1]  # normalize exactly
+
+        u01 = rng.random(int(length))
+        idx = np.searchsorted(cdf, u01, side="right")
+        idx = np.clip(idx, 0, w_flat.size - 1)
+
+        i_nu = idx // x_grid.size
+        i_x = idx % x_grid.size
+
+        nu_random = nu_grid[i_nu].astype(float)
+        x_random = x_grid[i_x].astype(float)
+
+        # -------------------------------------------------------------------------
+        # --- DW-consistent sampling of (e, p) given nu via (u=p/e, t=e^2) ----------
+        # Target: f(u|nu) ∝ (1-u^2) (3+u^2)^(-5/2) on u∈[-1,1]
+        # Two-stage rejection:
+        #   stage1: Uniform[-1,1] accepted with (1-u^2)  -> proposal ∝ (1-u^2)
+        #   stage2: accept with (3/(3+u^2))^(5/2)       -> adds (3+u^2)^(-5/2)
+        def draw_u(n):
+            out = np.empty(n, dtype=float)
+            filled = 0
+            while filled < n:
+                m = (n - filled) * 2 + 64
+                uu = rng.uniform(-1.0, 1.0, size=m)
+
+                # stage 1: accept with (1-u^2)
+                a1 = rng.random(m) < (1.0 - uu**2)
+                uu = uu[a1]
+                if uu.size == 0:
+                    continue
+
+                # stage 2: accept with (3/(3+u^2))^(5/2)
+                # This is always <= 1 since 3/(3+u^2) ∈ [3/4, 1]
+                a2 = rng.random(uu.size) < (3.0 / (3.0 + uu**2)) ** 2.5
+                uu = uu[a2]
+                if uu.size == 0:
+                    continue
+
+                take = min(uu.size, n - filled)
+                out[filled : filled + take] = uu[:take]
+                filled += take
+            return out
+
+        u_random = draw_u(int(length))
+
+        # Given u and nu:
+        # f(e|u,nu) ∝ e^4 exp(-alpha e^2), alpha=(5/2) nu^2 (3+u^2)
+        # Let t=e^2 => f(t|u,nu) ∝ t^(3/2) exp(-alpha t)  => Gamma(k=5/2, theta=1/alpha)
+        alpha = 2.5 * (nu_random**2) * (3.0 + u_random**2)
+        if np.any(~np.isfinite(alpha)) or np.any(alpha <= 0.0):
+            raise ValueError("cusps_Monte_Carlo: alpha invalid (non-finite or non-positive).")
+
+        t = rng.gamma(shape=2.5, scale=1.0 / alpha, size=int(length))
+        e_random = np.sqrt(t)
+        p_random = e_random * u_random
+
+        # -------------------------------------------------------------------------
+        # --- collapse factor f_ec (keep your existing definition/condition) -------
+        def fec_fun(fec, e, p):
+            return fec - 1.0 - 0.47 * (5.0 * (e**2 - p * np.abs(p)) * fec**2) ** 0.615
+
+        fec_random = np.full(int(length), np.nan, dtype=float)
+
+        # Condition used in your code: e^2 - p|p| < 0.26
+        cond = (e_random**2 - p_random * np.abs(p_random)) < 0.26
+        idx_solve = np.where(cond)[0]
+        if verbose:
+            print(f"cusps_Monte_Carlo: solving f_ec for {idx_solve.size}/{length} samples")
+
+        for j in idx_solve:
+            ej = float(e_random[j])
+            pj = float(p_random[j])
+            try:
+                sol = root(lambda f: fec_fun(f, ej, pj), x0=1.0)
+                if sol.success and np.isfinite(sol.x[0]) and sol.x[0] > 0.0:
+                    fec_random[j] = float(sol.x[0])
+                else:
+                    fec_random[j] = np.nan
+            except Exception:
+                fec_random[j] = np.nan
+
+        return x_random, nu_random, e_random, p_random, fec_random
+        
+        
+    def _load_or_generate_prompt_cusp_mc(
+        self,
+        length=10000,
+        mc_cache_file="data/prompt_cusps/prompt_cusps_Monte_Carlo.txt",
+        regenerate=False,
+        rng_seed=None,
+        verbose=False,
+    ):
+        """Load cached Monte Carlo samples for prompt-cusp peak parameters, or generate and cache them.
+
+        The cached file contains 5 columns in the following order:
+            x, nu, e, p, f_ec
+
+        Parameters
+        ----------
+        length : int
+            Number of Monte Carlo samples to generate if cache is missing or regeneration is requested.
+        mc_cache_file : str
+            Path to the cache file.
+        regenerate : bool
+            If True, ignore any existing cache and regenerate samples.
+        rng_seed : int or None
+            RNG seed passed to the generator for reproducibility.
+        verbose : bool
+            If True, print basic cache/generation info.
+
+        Returns
+        -------
+        x_random, nu_random, e_random, p_random, fec_random : 1D arrays
+        """
+
+        cache_path = mc_cache_file
+        cache_dir = os.path.dirname(cache_path)
+        if cache_dir:
+            os.makedirs(cache_dir, exist_ok=True)
+
+        if (not regenerate) and os.path.exists(cache_path):
+            try:
+                data = np.loadtxt(cache_path)
+                if data.ndim == 1:
+                    data = data.reshape(1, -1)
+                if data.shape[1] != 5:
+                    raise ValueError(f"Expected 5 columns (x,nu,e,p,f_ec) in {cache_path}, got {data.shape[1]}")
+                x_random, nu_random, e_random, p_random, fec_random = data.T
+                if verbose:
+                    print(f"prompt_cusps: loaded Monte Carlo cache: {cache_path} (N={x_random.size})")
+                return x_random, nu_random, e_random, p_random, fec_random
+            except Exception as exc:
+                if verbose:
+                    print(f"prompt_cusps: failed to load cache {cache_path} ({exc}); regenerating.")
+
+        # generate and cache
+        x_random, nu_random, e_random, p_random, fec_random = self.cusps_Monte_Carlo(
+            length=int(length),
+            rng_seed=rng_seed,
+            verbose=verbose,
+        )
+
+        header = (
+            "x, nu, e, p, f_ec\n"
+            "Generated by prompt_cusps.cusps_Monte_Carlo and cached for reproducibility." 
+        )
+        out = np.column_stack([x_random, nu_random, e_random, p_random, fec_random])
+        np.savetxt(cache_path, out, header=header)
+        if verbose:
+            print(f"prompt_cusps: saved Monte Carlo cache: {cache_path} (N={out.shape[0]})")
+
+        return x_random, nu_random, e_random, p_random, fec_random
+
+    def cusp_properties(
+        self,
+        f_surv=1.,
+        z=0.,
+        mc_length=10000,
+        mc_cache_file="data/prompt_cusps/prompt_cusps_Monte_Carlo.txt",
+        regenerate_mc=False,
+        rng_seed=None,
+        verbose=False,
+    ):
+
+        x_random, nu_random, e_random, p_random, fec_random = self._load_or_generate_prompt_cusp_mc(
+            length=mc_length,
+            mc_cache_file=mc_cache_file,
+            regenerate=regenerate_mc,
+            rng_seed=rng_seed,
+            verbose=verbose,
+        )
+
+        sigma,R_s,gamma         = self.sigma_function()
+        sigma_0,sigma_1,sigma_2 = sigma[0],sigma[1],sigma[2]
+
+        #num same as the one used in the sampling  
+        def f_x(x):
+            return (x**3-3.*x)/2.*(erf(np.sqrt(5./2.)*x)+erf(np.sqrt(5./8.)*x)) \
+                    +np.sqrt(2./(5.*np.pi))*((31./4.*x**2+8./5.)*np.exp(-(5./8.*x**2)) \
+                    +(x**2/2.-8./5.)*np.exp(-(5./2.*x**2)))
+
+        def ddn(nu,x):
+            return np.exp(-nu**2/2.)/((2.*np.pi)**2*R_s**3)*f_x(x) \
+                    *np.exp(-0.5*(x-gamma*nu)**2/(1.-gamma**2)) \
+                    /np.sqrt(2.*np.pi*(1.-gamma**2))
+        
+        #Differential number density of peaks
+        def n_peaks(nu=np.linspace(1.e-10,10.,num=1000),x=np.linspace(1.e-10,10.,num=1001)):
+            dndnudx_ = ddn(nu,x.reshape(-1,1))
+            n_peaks  = simpson(simpson(dndnudx_,nu,axis=-1),x)
+            return n_peaks
+        
+        #Scale factor
+        a  = 1./(1.+z)
+
+        #Growth index at small scales
+        g  = 0.901
+
+        #Critical density contrast for a spherical collapse
+        delta_ec = 1.686
+
+        #Averaged peak's characteristics
+        #delta           = nu_average*sigma_0
+        #dd_delta        = x_average*sigma_2
+        #delta_random    = nu_random*sigma_0             #Used for one of the conditions
+        
+        delta      = nu_random*sigma_0
+        dd_delta   = -x_random*sigma_2
+
+        collapsed  = (delta*a**g>1.686*fec_random)*(e_random**2-p_random*np.abs(p_random)<0.26)
+        f_coll     = np.sum(collapsed)/len(collapsed)
+        N_cusps_M  = f_surv*f_coll*n_peaks()/(self.OmegaC*self.rhocrit0)
+        N_peaks_M  = n_peaks()/(self.OmegaC*self.rhocrit0)
+        #print(N_peaks_M/(1.e3*self.Msun**-1))
+        
+        collapsed_indeces = np.where(collapsed)
+        
+        delta      = delta[collapsed_indeces]
+        dd_delta   = dd_delta[collapsed_indeces]
+        fec_random = fec_random[collapsed_indeces]
+        #x_random, nu_random, e_random, p_random, fec_random = x_random[collapsed_indeces], nu_random[collapsed_indeces], e_random[collapsed_indeces], p_random[collapsed_indeces], fec_random[collapsed_indeces]
+        #Cusp properties
+        R       = np.sqrt(np.abs(delta/dd_delta))
+        delta_a = delta*a**g
+        a_coll  = (fec_random*delta_ec/delta_a)**(1./g)*a
+        Aec     = 24.*(self.OmegaC*self.rhocrit0)*a_coll**-1.5*R**1.5
+        rcusp   = 0.11*a_coll*R
+        f_max   = (2.*np.pi)**(-3./2.)*(self.m_chi/self.T_kd)**(3./2.)*self.OmegaC*self.rhocrit0*self.a_kd**-3
+        rcore   = (3.e-5*self.G**-3*f_max**-2*Aec**-1*self.c**6)**(1./4.5)
+        Mcusp   = 8.*np.pi/3.*Aec*rcusp**1.5
+        #print(np.mean(R/self.pc), np.mean(rcore/self.pc), np.mean(rcusp/self.pc), np.mean(rcusp/rcore))
+
+        #Calculate number of cusps
+
+        idx = np.where(collapsed)[0]
+        if idx.size==0:
+            J_cusp = 0.
+        else:
+            J_cusp       = 4*np.pi*Aec**2*(0.531+np.log(rcusp/rcore))
+            J_cusp_mean  = np.mean(J_cusp)
+
+        #Calculate the annihilation factor per unit dark matter mass
+        J_cusps_M = J_cusp_mean*N_cusps_M
+        J_cusps_fit = 0.08*f_surv*(np.log(self.m_chi*self.T_kd/self.GeV**2)+36.)**5*(self.OmegaC*self.rhocrit0)
+        
+        #print(np.mean(R)/self.pc,np.mean(a_coll),f_coll)
+        #print(np.mean(Aec)/(self.Msun*self.pc**-1.5),np.mean(rcore)/self.pc,np.mean(rcusp)/self.pc,np.mean(Mcusp)/self.Msun)
+        #print(f_coll, np.mean(J_cusp)/(self.Msun**2*self.pc**-3))
+        #print(np.mean(Mcusp)/self.Msun,np.mean(a_coll),np.mean(R)/self.pc)
+        #print(f_coll,N_cusps_M/(1.e3*self.Msun**-1),J_cusps_M/(self.Msun*self.pc**-3),J_cusps_fit/(self.Msun*self.pc**-3))
+
+        return f_coll, J_cusp

--- a/sashimi_c.py
+++ b/sashimi_c.py
@@ -10,6 +10,7 @@ from scipy.interpolate import interp1d
 from scipy.interpolate import griddata
 from scipy.special import erf
 from numpy.polynomial.hermite import hermgauss
+import os
 import warnings
 warnings.filterwarnings("ignore", category=RuntimeWarning, append=1)
 
@@ -106,7 +107,7 @@ class cosmology(units_and_constants):
     def dDdz(self, z):
         def dOdz(z):
             return -self.OmegaL*3*self.OmegaM*(1+z)**2*(self.OmegaL+self.OmegaM*(1+z)**3.)**-2
-        Omega_Lz = self.OmegaL*pow(self.OmegaL+self.OmegaM*pow(self.h,-2)*pow(1+z,3),-1)
+        Omega_Lz = self.OmegaL/(self.OmegaL+self.OmegaM*(1.+z)**3)
         Omega_Mz = 1-Omega_Lz
         phiz     = Omega_Mz**(4./7.)-Omega_Lz+(1+Omega_Mz/2.)*(1+Omega_Lz/70.)
         phi0     = self.OmegaM**(4./7.)-self.OmegaL+(1+self.OmegaM/2.)*(1+self.OmegaL/70.)
@@ -119,18 +120,51 @@ class cosmology(units_and_constants):
 class halo_model(cosmology):
 
     
-    def __init__(self):
+    def __init__(self, prompt_cusps=False, k_fs_Mpc=1.06e6, filter='Sharp-k', alpha=1.8):
         cosmology.__init__(self)
-
+        self.prompt_cusps  = prompt_cusps
+        self.k_fs          = k_fs_Mpc*self.Mpc**-1
+        self.filter        = filter
+        self.alpha         = alpha
         
-    def xi(self, M):
-        return (M/((1.e10*self.Msun)/self.h))**-1
+        if prompt_cusps:
+            # Prompt-cusp path: build sigma(M) / dsigma^2/dM from the CAMB power
+            # spectrum. Imported lazily so standard (non-cusp) usage never loads
+            # the prompt_cusps module.
+            from prompt_cusps import build_ps_interpolators
+            self.sigma_interp, self.dsdm_interp = build_ps_interpolators(
+                self, self.k_fs, filter=filter, alpha=alpha)
 
+
+    def sigmaMz(self, M, z):
+        if self.prompt_cusps==False:
+            return self.sigma_Ludlow(M)*self.growthD(z)
+        else:
+            return self.sigma_interp(np.log10(M/self.Msun))*self.growthD(z)
+
+
+    def dsdm(self, M, z):
+        if self.prompt_cusps==False:
+            return self.dsdm_Ludlow(M)*self.growthD(z)**2
+        else:
+            return self.dsdm_interp(np.log10(M/self.Msun))*self.growthD(z)**2
     
-    def sigmaMz(self, M, z):    
+    
+    def sigma_Ludlow(self, M):
         """ Ludlow et al. (2016) """
-        return self.growthD(z)*22.26*self.xi(M)**0.292/(1.+1.53*self.xi(M)**0.275+3.36*self.xi(M)**0.198)
+        xi = lambda M: (M/((1.e10*self.Msun)/self.h))**-1
+        return 22.26*xi(M)**0.292/(1.+1.53*xi(M)**0.275+3.36*xi(M)**0.198)
 
+
+    def dsdm_Ludlow(self, M):
+        """ Ludlow et al. (2016) """
+        xi = lambda M: (M/((1.e10*self.Msun)/self.h))**-1
+        dsdsigma  = 2.*self.sigma_Ludlow(M)
+        dxidm     = -1.e10*self.Msun/self.h/M**2
+        dsigmadxi = self.sigma_Ludlow(M)*(0.292/xi(M)-(0.275*1.53*xi(M)**-0.725+0.198*3.36* \
+            xi(M)**-0.802)/(1.+1.53*xi(M)**0.275+3.36*xi(M)**0.198))
+        return dsdsigma*dsigmadxi*dxidm
+        
 
     def deltac_func(self, z):
         return 1.686/self.growthD(z)
@@ -218,28 +252,8 @@ class halo_model(cosmology):
         Mzzidef = Mzi0*(1.+z-zi)**alpha*np.exp(beta*(z-zi))
         Mzzivir = self.Mvir_from_M200_fit(Mzzidef,z)
         return (beta+alpha/(1.+z-zi))*Mzzivir
-
+        
     
-    def dsdm(self,M,z):  
-        """ Ludlow et al. (2016) """
-        s         = self.sigmaMz(M,z)**2
-        dsdsigma  = 2.*self.sigmaMz(M,z)
-        dxidm     = -1.e10*self.Msun/self.h/M**2
-        dsigmadxi = self.sigmaMz(M,z)*(0.292/self.xi(M)-(0.275*1.53*self.xi(M)**-0.725+0.198*3.36* \
-            self.xi(M)**-0.802)/(1.+1.53*self.xi(M)**0.275+3.36*self.xi(M)**0.198))
-        return dsdsigma*dsigmadxi*dxidm
-
-    
-    def dlogSdlogM(self,M,z):  
-        """ Ludlow et al. (2016) """
-        s         = self.sigmaMz(M,z)**2
-        dsdsigma  = 2.*self.sigmaMz(M,z)
-        dxidm     = -1.e10*self.Msun/self.h/M**2
-        dsigmadxi = self.sigmaMz(M,z)*(0.292*pow(self.xi(M),-1)-(0.275*1.53*pow(self.xi(M),-0.725)+0.198*3.36* \
-            pow(self.xi(M),-0.802))*pow(1.+1.53*pow(self.xi(M),0.275)+3.36*pow(self.xi(M),0.198),-1))
-        return (M/s)*dsdsigma*dsigmadxi*dxidm
-
-
 
 
 class TidalStrippingSolver(halo_model):
@@ -523,12 +537,12 @@ class TidalStrippingSolver(halo_model):
         eps_22 = self.eps_22(za, z)
         ln_ma = np.log(ma)
         # NOTE: Shanks transformation
-        # For A_n = \sum_{i=0}^{n} a_i, the Shanks transformation is given by
+        # For A_n = sum_{i=0}^{n} a_i, the Shanks transformation is given by
         #  S_n = A_{n+1} - (A_{n+1} - A_n)^2 / (A_{n+1} - 2A_n + A_{n-1})
         #      = A_{n+1} - (A_{n+1} - A_n)^2 / ((A_{n+1} - A_n) - (A_n - A_{n-1}))
-        # Since A_n = \sum_{i=0}^{n} a_i, we can write
+        # Since A_n = sum_{i=0}^{n} a_i, we can write
         #  S_n = A_{n+1} - a_{n+1}^2 / (a_{n+1} - a_n)
-        # In our case, we calculate the epsilon as eps = \sum_{i=0}^{n} eps_i.
+        # In our case, we calculate the epsilon as eps = sum_{i=0}^{n} eps_i.
         # Therefore, we can apply Shanks transformation to eps up to the second order as follows:
         # S_2 = (eps_0 + eps_1 + eps_2) - eps_2^2 / (eps_2 - eps_1)
         eps_1 = eps_10 + ln_ma * eps_11
@@ -615,9 +629,8 @@ class TidalStrippingSolver(halo_model):
     
 class subhalo_properties(halo_model):
 
-    
-    def __init__(self):
-        halo_model.__init__(self)
+    def __init__(self, prompt_cusps=False, k_fs_Mpc=1.06e6, filter='Sharp-k', alpha=1.8):
+        halo_model.__init__(self, prompt_cusps=prompt_cusps, k_fs_Mpc=k_fs_Mpc, filter=filter, alpha=alpha)
 
     
     def Ffunc(self, dela, s1, s2):
@@ -700,7 +713,7 @@ class subhalo_properties(halo_model):
     
     def subhalo_properties_calc(self, M0, redshift=0.0, dz=0.01, zmax=7.0, N_ma=500, sigmalogc=0.128,
                                 N_herm=5, logmamin=-6, logmamax=None, N_hermNa=200, Na_model=3, 
-                                ct_th=0.77, profile_change=True, M0_at_redshift=False, method="pert2_shanks", **kwargs):
+                                ct_th=0.0, profile_change=True, M0_at_redshift=False, method="pert2_shanks", **kwargs):
         """
         This is the main function of SASHIMI-C, which makes a semi-analytical subhalo catalog.
         
@@ -729,7 +742,8 @@ class subhalo_properties(halo_model):
                                    used in Na_calc. (default: 200)
         (Optional) Na_model:       Model number of EPS defined in Yang et al. (2011). (default: 3)
         (Optional) ct_th:          Threshold value for c_t(=r_t/r_s) parameter, below which a subhalo is assumed to
-                                   be completely desrupted. Suggested values: 0.77 (default) or 0 (no desruption).
+                                   be completely desrupted. Suggested values: 0.77 (desruption)
+                                   or 0.0 (no desruption; default).
         (Optional) profile_change: Whether we implement the evolution of subhalo density profile through tidal
                                    mass loss. (default: True)
         (Optional) M0_at_redshift: If True, M0 is regarded as the mass at a given redshift, instead of z=0.
@@ -762,9 +776,10 @@ class subhalo_properties(halo_model):
 
         if M0_at_redshift:
             Mz        = M0
-            M0_list   = np.logspace(0.,3.,1000)*Mz
-            fint      = interp1d(self.Mzi(M0_list,redshift),M0_list)
-            M0        = fint(Mz)
+            M0_list   = np.logspace(0.,5.,1500)*Mz
+            fint      = interp1d(self.Mzi(M0_list,redshift),M0_list,
+                                 bounds_error=False, fill_value="extrapolate")
+            M0        = float(fint(Mz))
         self.M0       = M0
         self.redshift = redshift
         
@@ -819,12 +834,12 @@ class subhalo_properties(halo_model):
             survive[iz]   = np.where(ct_z0[iz]>ct_th,1,0)
             m0_matrix[iz] = m0*np.ones((N_herm,1))
 
-        Na           = self.Na_calc(ma,zdist,M0,z0=0.,N_herm=N_hermNa,Nrand=1000,
+        Na           = self.Na_calc(ma200,zdist,M0,z0=0.,N_herm=N_hermNa,Nrand=1000,
                                     Na_model=Na_model)
-        Na_total     = integrate.simpson(integrate.simpson(Na,x=np.log(ma)),x=np.log(1+zdist))
+        Na_total     = integrate.simpson(integrate.simpson(Na,x=np.log(ma200)),x=np.log(1+zdist))
         weight       = Na/(1.+zdist.reshape(-1,1))
         weight       = weight/np.sum(weight)*Na_total
-        weight       = (weight.reshape((len(zdist),1,len(ma))))*w1/np.sqrt(np.pi)
+        weight       = (weight.reshape((len(zdist),1,len(ma200))))*w1/np.sqrt(np.pi)
         z_acc        = (zdist.reshape(-1,1,1))*np.ones((1,N_herm,N_ma))
         z_acc        = z_acc.reshape(-1)
         ma200        = ma200*np.ones((len(zdist),N_herm,1))
@@ -847,8 +862,9 @@ class subhalo_observables(subhalo_properties):
     
     
     def __init__(self, M0_per_Msun, redshift=0., dz=0.01, zmax=7.0, N_ma=500, sigmalogc=0.128,
-                 N_herm=5, logmamin=-6, logmamax=None, N_hermNa=200, Na_model=3,
-                 ct_th=0.77, profile_change=True, M0_at_redshift=False,method="pert2_shanks", **kwargs):
+                 N_herm=5, logmamin=-6, logmamax=None, N_hermNa=200, Na_model=3, ct_th=0.0,
+                 profile_change=True, M0_at_redshift=False, prompt_cusps=False, k_fs_Mpc=1.06e6,
+                 filter='Sharp-k', alpha=1.8, method="pert2_shanks", **kwargs):
         """
         This class computes various subhalo observables in a host halo. 
         
@@ -878,7 +894,8 @@ class subhalo_observables(subhalo_properties):
                                    used in Na_calc. (default: 200)
         (Optional) Na_model:       Model number of EPS defined in Yang et al. (2011). (default: 3)
         (Optional) ct_th:          Threshold value for c_t(=r_t/r_s) parameter, below which a subhalo is assumed to
-                                   be completely disrupted. Suggested values: 0.77 (default) or 0 (no disruption).
+                                   be completely disrupted. Suggested values: 0.77 (disruption) or 0.0
+                                   (no disruption; default).
         (Optional) profile_change: Whether we implement the evolution of subhalo density profile through tidal
                                    mass loss. (default: True)
         (Optional) M0_at_redshift: If True, M0 is regarded as the mass at a given redshift, instead of z=0.
@@ -919,7 +936,7 @@ class subhalo_observables(subhalo_properties):
 
         """
 
-        subhalo_properties.__init__(self)
+        subhalo_properties.__init__(self,prompt_cusps=prompt_cusps,k_fs_Mpc=k_fs_Mpc,filter=filter,alpha=alpha)
         ma200, z_a, rs_a, rhos_a, m0, rs0, rhos0, ct0, weight, survive \
             = self.subhalo_properties_calc(M0_per_Msun*self.Msun,redshift,dz,zmax,N_ma,sigmalogc,N_herm,
                                            logmamin,logmamax,N_hermNa,Na_model,ct_th,profile_change,
@@ -937,6 +954,8 @@ class subhalo_observables(subhalo_properties):
         self.Vmax   = np.sqrt(4.*np.pi*self.G*self.rhos0/4.625)*self.rs0
         self.rpeak  = 2.163*self.rs_a
         self.Vpeak  = np.sqrt(4.*np.pi*self.G*self.rhos_a/4.625)*self.rs_a
+        
+        self.redshift = redshift
 
 
     def mass_function(self, evolved=True):
@@ -1056,7 +1075,7 @@ class subhalo_observables(subhalo_properties):
 
     def mass_fraction(self, evolved=True):
         """
-        Subhalo mass fraction: \sum_i m_i / M_host
+        Subhalo mass fraction: sum_i m_i / M_host
         
         -----
         Input
@@ -1115,7 +1134,7 @@ class subhalo_observables(subhalo_properties):
         if n==0:
             fssh = 0.
             Bssh = 0.
-        else:                        
+        else:     
             list_Bssh = np.loadtxt('data/boost/Bsh_%s.txt'%(n-1))
             list_fssh = np.loadtxt('data/boost/fsh.txt')
             list_za  = np.loadtxt('data/boost/za.txt')
@@ -1165,6 +1184,117 @@ class subhalo_observables(subhalo_properties):
         luminosity_ratio = 1.-fsh**2+Bsh
         
         return Bsh, luminosity_ratio
+
+
+    def annihilation_boost_factor_prompt_cusps(self, n=0, f_surv=1., f_surv_stripped=1.):
+        """
+        Annihilation boost factor B_{sh}. Note that the effect of sub-subhalos and higher order
+        structure is not included.
+        
+        -----
+        Input
+        -----
+        (Optional) n:       The effects up to sub^{n}-subhalos will be included. 
+                            If n=0 (default), no sub-subhalos and beyond is considered.
+                            For other values of n, the function requires pre-computed boost factors
+                            B_sh from the previous (n-1)th iteration and subhalo mass fraction f_sh.
+                            These are stored under 'data/boost/' directory. If the directory does not
+                            exist, excecuting 'boost_iteraction.py' will generate the  necessary files
+                            and store them in the directory, up to n = 3.
+        (Optional) evolved: If True (False), this function calculates evolved (unevolved) mass function.
+                            Here 'evolved' means that subhalos experiences tidal mass loss, whereas
+                            'unevolved' means that mass loss is ignored.
+                            
+        ------
+        Output
+        ------
+        Bsh:              Annihilation boost factor B_{sh}. See Eq. (37) of Ando et al.
+                          arXiv:1903.11427 for definition.
+        luminosity_ratio: Ratio of the total luminosity (subhalos+host) and the luminosity due
+                          to host only in the absence of subhalos:
+                          L_{total}/L_{host,0} = 1-f_{sh}^2+B_{sh}
+        
+        """
+
+        from prompt_cusps import prompt_cusps as _prompt_cusps
+        prc    = _prompt_cusps(k_fs=self.k_fs)
+        f_coll, J_cusps = prc.cusp_properties(f_surv=1.0,z=self.redshift)
+        J_cusps_mean    = np.mean(J_cusps)
+        
+        fsh = self.mass_fraction()
+        if n==0:
+            fssh          = 0.
+            Bssh          = 0.
+            Ncusp_dressed = 0.
+            Ncusp_naked   = 0.
+        else:                        
+            list_Bssh           = np.loadtxt('data/prompt_cusps/boost/Bsh_%s_%.1f_%.1f.txt'%((n-1),f_surv,f_surv_stripped))
+            list_Ncusp_dressed  = np.loadtxt('data/prompt_cusps/boost/Ncusp_dressed_%s_%.1f_%.1f.txt'%((n-1),f_surv,f_surv_stripped))
+            list_Ncusp_naked    = np.loadtxt('data/prompt_cusps/boost/Ncusp_naked_%s_%.1f_%.1f.txt'%((n-1),f_surv,f_surv_stripped))
+            list_fssh           = np.loadtxt('data/prompt_cusps/boost/fsh.txt')
+            list_za             = np.loadtxt('data/prompt_cusps/boost/za.txt')
+            list_ma             = np.loadtxt('data/prompt_cusps/boost/ma.txt')
+
+            list_log_ma_flat             = np.log10(list_ma.flatten())
+            list_za_flat                 = (list_za.reshape(-1,1)*np.ones_like(list_ma[0])).flatten()
+            list_log_fssh_flat           = np.log10(list_fssh.flatten())
+            list_log_Bssh_flat           = np.log10((list_Bssh+1.e-30).flatten())
+            list_log_Ncusp_dressed_flat  = np.log10((list_Ncusp_dressed).flatten())
+            list_log_Ncusp_naked_flat    = np.log10((list_Ncusp_naked).flatten())
+
+            log_Bssh           = griddata((list_log_ma_flat,list_za_flat),list_log_Bssh_flat,(np.log10(self.ma200),self.z_a),method='linear')
+            log_Ncusp_dressed  = griddata((list_log_ma_flat,list_za_flat),list_log_Ncusp_dressed_flat,(np.log10(self.ma200),self.z_a),method='linear')
+            log_Ncusp_naked    = griddata((list_log_ma_flat,list_za_flat),list_log_Ncusp_naked_flat,(np.log10(self.ma200),self.z_a),method='linear')
+            log_fssh           = griddata((list_log_ma_flat,list_za_flat),list_log_fssh_flat,(np.log10(self.ma200),self.z_a),method='linear')
+
+            log_Bssh[~np.isfinite(log_Bssh)]                    = -np.inf
+            log_Ncusp_dressed[~np.isfinite(log_Ncusp_dressed)]  = -np.inf
+            log_Ncusp_naked[~np.isfinite(log_Ncusp_naked)]      = -np.inf
+            log_fssh[~np.isfinite(log_fssh)]                    = -np.inf
+            Bssh            = 10.**log_Bssh
+            Ncusp_dressed0  = 10.**log_Ncusp_dressed
+            Ncusp_naked0    = 10.**log_Ncusp_naked
+            fssh            = 10.**log_fssh
+
+            mavir = self.Mvir_from_M200_fit(self.ma200,self.z_a)
+            Oz    = self.OmegaM*(1.+self.z_a)**3/self.g(self.z_a)
+            ravir = np.cbrt(3.*mavir/(4.*np.pi*self.rhocrit(self.z_a)*self.Delc(Oz-1.)))
+            cavir = ravir/self.rs_a
+
+            fssh = fssh*self.rs0**3*(np.arcsinh(self.ct0)-self.ct0/np.sqrt(1.+self.ct0**2))
+            fssh = fssh/(self.rs_a**3*(np.arcsinh(cavir)-cavir/np.sqrt(1.+cavir**2)))
+            fssh = fssh/(self.rhos0*self.rs0**3*self.fc(self.ct0))
+            fssh = fssh*(self.rhos_a*self.rs_a**3*self.fc(cavir))
+
+            Bssh = Bssh*self.rs0**3*(np.arcsinh(self.ct0)-self.ct0/np.sqrt(1.+self.ct0**2))
+            Bssh = Bssh/(self.rs_a**3*(np.arcsinh(cavir)-cavir/np.sqrt(1.+cavir**2)))
+            Bssh = Bssh/(self.rhos0**2*self.rs0**3*(1.-1./(1.+self.ct0)**3))
+            Bssh = Bssh*(self.rhos_a**2*self.rs_a**3*(1.-1./(1.+cavir)**3))
+            
+            Ncusp_dressed  = Ncusp_dressed0*self.rs0**3*(np.arcsinh(self.ct0)-self.ct0/np.sqrt(1.+self.ct0**2)) \
+                /(self.rs_a**3*(np.arcsinh(cavir)-cavir/np.sqrt(1.+cavir**2)))
+            Ncusp_naked    = Ncusp_naked0+f_surv_stripped*(Ncusp_dressed0-Ncusp_dressed)
+
+        Ncusp_dressed  = f_surv*np.sum(self.weight)+np.sum(Ncusp_dressed*self.weight)
+        Ncusp_naked    = np.sum(Ncusp_naked*self.weight)
+
+        Lsh       = np.sum((1.-fssh**2+Bssh)*4.*np.pi/3.*self.rhos0**2*self.rs0**3*(1.-1./(1.+self.ct0)**3)*self.weight)
+        Lcusp_dressed  = J_cusps_mean*Ncusp_dressed
+        Lcusp_naked    = J_cusps_mean*Ncusp_naked
+            
+        Mhost     = self.Mzi(self.M0,self.redshift)
+        r200_host = (3.*Mhost/(4.*np.pi*self.rhocrit(self.redshift)*200.))**(1./3.)
+        c200_host = self.conc200(Mhost,self.redshift)
+        rs_host   = r200_host/c200_host
+        rhos_host = Mhost/(4.*np.pi*rs_host**3*self.fc(c200_host))
+        Lhost0    = 4.*np.pi/3.*rhos_host**2*rs_host**3*(1.-1./(1.+c200_host)**3)
+
+        Bsh               = Lsh/Lhost0
+        Bcusp_dressed     = Lcusp_dressed/Lhost0
+        Bcusp_naked       = Lcusp_naked/Lhost0
+        luminosity_ratio  = 1.-fsh**2+Bsh+Bcusp_dressed+Bcusp_naked
+        
+        return Bsh, Bcusp_dressed, Bcusp_naked, luminosity_ratio, Ncusp_dressed, Ncusp_naked
 
     
     def subhalo_catalog_MC(self, mth):


### PR DESCRIPTION
## Summary

Adds **prompt cusps** (relevant only for the dark-matter **annihilation** signal) as a clean, opt-in feature, and folds the general fixes from the `prompt_cusps` work into `main`.

Prompt cusps are **off by default** and fully isolated in a new module, **`prompt_cusps.py`**, which is **imported lazily** — standard (non-annihilation) usage never loads it and is behaviourally unchanged.

## On / off design

- New constructor flag `prompt_cusps=False` on `halo_model` / `subhalo_properties` / `subhalo_observables`.
- `prompt_cusps=False` (default): standard Ludlow sigma(M) path; `prompt_cusps.py` is **never imported**.
- `prompt_cusps=True`: sigma(M) is built from the CAMB linear matter power spectrum (free-streaming cutoff via `k_fs_Mpc` / `filter` / `alpha`); the heavy code is loaded lazily from `prompt_cusps.py`.
- Annihilation boost with cusps: `subhalo_observables.annihilation_boost_factor_prompt_cusps(...)`.

## Files

- **`prompt_cusps.py`** (new) — the `prompt_cusps` class + `build_ps_interpolators` (CAMB power-spectrum sigma path). All prompt-cusp physics lives here.
- **`sashimi_c.py`** — adds the flag + lazy hooks; general fixes (below). No prompt-cusp physics remains inline.
- **`boost_iteration_prompt_cusps.py`** (new) — driver to pre-compute the `n>0` boost tables.
- **`README.md`** — prompt-cusps usage + version table.

## Behaviour changes (affect ALL users, not only prompt cusps)

- **`ct_th` default `0.77 -> 0.0`** (tidal-disruption threshold; `0.0` = no disruption). Pass `ct_th=0.77` to recover the previous behaviour.
- **`dDdz` bugfix** (erroneous `h^-2` factor removed). Also `Na_calc` now uses `ma200`, and the `M0_at_redshift` `M0_list` grid was widened.

## Versioning (tags to apply AFTER merge)

| Tag | Commit |
|-----|--------|
| v1.0 | `8eec3f1` (first public upload) -- please confirm |
| v1.1 | `f3dbf03` (current `main`, efficiency version) |
| v1.2 | this PR's merge commit |

## Testing (glow311: numpy 1.26.4 / scipy 1.16.1)

- `import sashimi_c` does **not** import `prompt_cusps` (lazy); default `subhalo_observables(...)` + `mass_function()` run.
- `prompt_cusps=True`: `build_ps_interpolators` runs; `annihilation_boost_factor_prompt_cusps(n=0)` returns sensible values; MC cache generated.
- All three modules compile cleanly.

## Notes

- `data/` is gitignored; required inputs (`Planck2018_CAMB_extrap.dat`, `powerspectrum31.txt`) and boost tables are **not** in the PR (local-only, as before).
- Based on the `prompt_cusps` branch + your local WIP (the vectorized version). Your uncommitted WIP working tree was **not** touched (built via a separate worktree off `origin/main`).